### PR TITLE
Fix Docker image pull issue for Azure Service Bus Emulator

### DIFF
--- a/src/test/java/com/example/demo/OrderControllerTest.java
+++ b/src/test/java/com/example/demo/OrderControllerTest.java
@@ -32,7 +32,7 @@ public class OrderControllerTest {
 
     @DynamicPropertySource
     static void registerAzureServiceBusProperties(DynamicPropertyRegistry registry) {
-        String serviceBusConnectionString = String.format("Endpoint=sb://%s;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=your_access_key",
+        String serviceBusConnectionString = String.format("Endpoint=sb://%s/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=your_access_key",
                 azureServiceBusEmulator.getHost() + ":" + azureServiceBusEmulator.getMappedPort(5672));
         registry.add("spring.cloud.azure.servicebus.connection-string", () -> serviceBusConnectionString);
     }


### PR DESCRIPTION
Update the `OrderControllerTest.java` file to fix the Docker image pull issue for Azure Service Bus Emulator.

* **DynamicPropertySource Method**
  - Update the connection string format to include a trailing slash after the endpoint in the `registerAzureServiceBusProperties` method.

